### PR TITLE
Allow compilation on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ c_priv:
 	mkdir -p priv/c
 
 clean:
-	rm -f priv/c $(OBJ) $(BEAM_FILES)
+	rm -rf priv/c $(OBJ) $(BEAM_FILES)

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule Porty.MixProject do
   defp make_env do
     case :os.type() do
       {:unix, :darwin} ->
-        libbsd_path = "/opt/homebrew/opt/libbsd"
+        {prefix, 0} = System.cmd("brew", "--prefix")
+        libbsd_path = Path.join(prefix, "opt/libbsd")
 
         if File.dir?(libbsd_path) do
           %{

--- a/mix.exs
+++ b/mix.exs
@@ -43,18 +43,14 @@ defmodule Porty.MixProject do
   defp make_env do
     case :os.type() do
       {:unix, :darwin} ->
-        # 1. Dynamically find the Homebrew prefix
-        {brew_prefix, 0} = System.cmd("brew", ["--prefix"], stderr_to_stdout: true)
-        libbsd_path = "#{String.trim(brew_prefix)}/opt/libbsd"
+        libbsd_path = "/opt/homebrew/opt/libbsd"
 
-        # 2. Check if the directory exists
         if File.dir?(libbsd_path) do
           %{
             "CPPFLAGS" => "-I#{libbsd_path}/include",
             "LDFLAGS" => "-L#{libbsd_path}/lib"
           }
         else
-          # 3. Raise an error for the user
           Mix.raise """
           \n[Missing Dependency] libbsd was not found at #{libbsd_path}.
           Since you are on macOS, this library is required for compilation.


### PR DESCRIPTION
Auf macOS werden Include-Files und Libs von libbsd beim Kompilieren/Linken nicht gefunden, da sie nicht im Standard-Pfad liegen.
Deshalb müssen wir CPPFLAGS und LDFLAGS entsprechend anpassen.